### PR TITLE
Adding unique keys, should handle upsert on id only, unique only, id and unique fields provided.

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,10 +161,10 @@ function PgMutationUpsertPlugin(builder) {
 
           // Figure out to which column that unique constraint belongs to
           const uniqueKeys =
-            uniqueConstraint &&
+            (uniqueConstraint &&
             uniqueConstraint.keyAttributeNums.map(
               num => attributes.filter(attr => attr.num === num)[0]
-            );
+            )) || [];
 
           // Create upsert fields from each introspected table
           const fieldName = `upsert${tableTypeName}`


### PR DESCRIPTION
This PR adds support for unique columns, only for the index.js, not batch yet as I wanted to get feedback before doing any further work.

Provided a table set up like:
```
CREATE TABLE public.example (
    id integer NOT NULL,
    notuniq text,
    uniq text
);

CREATE SEQUENCE public.example_id_seq
    START WITH 1
    INCREMENT BY 1
    NO MINVALUE
    NO MAXVALUE
    CACHE 1;

ALTER TABLE ONLY public.example ALTER COLUMN id SET DEFAULT nextval('public.example_id_seq'::regclass);

ALTER TABLE ONLY public.example
    ADD CONSTRAINT example_uniq_key UNIQUE (uniq);

ALTER TABLE ONLY public.example
    ADD CONSTRAINT example_id_uniq_key UNIQUE (id, uniq);

ALTER TABLE ONLY public.example
    ADD CONSTRAINT example_pkey PRIMARY KEY (id);
```

I would like to be able to issue the following kinds of graphql queries for upsert with success:
Mutation:
```
mutation upsertExample($upsertExampleInput: UpsertExampleInput!) {
  upsertExample(input: $upsertExampleInput) {
    example {
      id
      notuniq
      uniq
    }
  }
}
```
Variable with only the unique column specified (as primary is generated in this case):
```
{
  "upsertExampleInput": {
    "example": {
      "uniq": "one"
    }
  }
}
```
And get result:
```
{
  "data": {
    "upsertExample": {
      "example": {
        "id": 1,
        "notuniq": null,
        "uniq": "one"
      }
    }
  }
}
```
Variable with the unique column specified (record already exists):
```
{
  "upsertExampleInput": {
    "example": {
      "uniq": "one",
      "notuniq": "random stuff"
    }
  }
}
```
And get result:
```
{
  "data": {
    "upsertExample": {
      "example": {
        "id": 1,
        "notuniq": "random stuff",
        "uniq": "one"
      }
    }
  }
}
```
Variable with id and the unique column specified (record already exists):
```
{
  "upsertExampleInput": {
    "example": {
      "id": 1,
      "uniq": "one",
      "notuniq": "random stuff test with id and uniq column"
    }
  }
}
```
And get result:
```
{
  "data": {
    "upsertExample": {
      "example": {
        "id": 1,
        "notuniq": "random stuff test with id and uniq column",
        "uniq": "one"
      }
    }
  }
}
```
Variable with just id column specified (record already exists):
```
{
  "upsertExampleInput": {
    "example": {
      "id": 1,
      "notuniq": "random stuff test with just id"
    }
  }
}
```
And get result:
```
{
  "data": {
    "upsertExample": {
      "example": {
        "id": 1,
        "notuniq": "random stuff test with just id",
        "uniq": "one"
      }
    }
  }
}
```